### PR TITLE
Bump openmm dev package to 7.1.0 (still going to 'dev' label)

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openmm
-  version: 0.0.0
+  version: 7.1.0
 
 source:
   git_url: https://github.com/pandegroup/openmm.git


### PR DESCRIPTION
This will label the openmm `dev` package 7.1.0, but the package will still go to the `dev` label, so there should be no risk of users accidentally picking this up unless they have manually added the `dev` label to their channels.
