### PR TITLE
Update test build for testing 7.1 beta conda recipe for linux and osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ env:
 # available in this repo at devtools/centos5-build-box/Dockerfile
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker pull jchodera/omnia-build-box:cuda${CUDA_SHORT_VERSION}-amd30;
+      docker pull jchodera/omnia-build-box:cuda${CUDA_SHORT_VERSION}-amd30-clang38;
     fi
 
 script:
   # Retrieve conda-build-all
-  - wget -O conda-build-all --quiet https://raw.githubusercontent.com/omnia-md/conda-recipes/master/conda-build-all
+  - wget -O conda-build-all --no-check-certificate --quiet https://raw.githubusercontent.com/omnia-md/conda-recipes/master/conda-build-all
   - chmod u+x conda-build-all
   # Select upload destination
   - if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" ]]; then
@@ -42,12 +42,12 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
         docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST -e CONDA_BUILD
-            -t -i --rm -v `pwd`:/io jchodera/omnia-build-box:cuda${CUDA_SHORT_VERSION}-amd30
+            -t -i --rm -v `pwd`:/io jchodera/omnia-build-box:cuda${CUDA_SHORT_VERSION}-amd30-clang38
             bash /io/devtools/docker-build.sh;
 
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 
         echo "Building osx...";
         bash devtools/osx-build.sh;
-        
+
     fi

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 # Fix hbb issues
-ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
-ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
+if [ ! -e /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ ]; then
+    ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
+fi
+if [ ! -e /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ ]; then
+    ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
+fi
 
 # holy build box paths
 export HBB_PREFIX="/hbb_shlib"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -8,9 +8,13 @@ if [ ! -e /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ ]
     ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
 fi
 
+# Save anaconda path
+export PYTHON=`which python`
+export PYTHONBIN=`dirname $PYTHON`
+
 # holy build box paths
 export HBB_PREFIX="/hbb_shlib"
-export PATH=$PATH:$HBB_PREFIX/bin:/hbb/bin
+export PATH=$HBB_PREFIX/bin:/hbb/bin:$PATH
 export C_INCLUDE_PATH=$HBB_PREFIX/include
 export CPLUS_INCLUDE_PATH=$HBB_PREFIX/include
 export LIBRARY_PATH=$HBB_PREFIX/lib
@@ -31,7 +35,10 @@ export SHLIB_LDFLAGS="$LDPATHFLAGS -static-libstdc++"
 
 # Clang paths
 export CLANG_PREFIX="/opt/clang"
-export PATH=$PATH:$CLANG_PREFIX/bin
+export PATH=$CLANG_PREFIX/bin:$PATH
+
+# Add back anaconda path at front
+export PATH=$PYTHONBIN:$PATH
 
 # OpenMM paths
 CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -13,9 +13,14 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     # For Docker build
     #
 
-    # Fix hbb issues
-    ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
-    ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
+    # Fix hbb issues.
+    # If statements needed because multiple Python versions are built in same docker image.
+    if [ ! -e /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux ]; then
+        ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
+    fi
+    if [ ! -e /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux ]; then
+        ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
+    fi
 
     # Clang paths
     export CLANG_PREFIX="/opt/clang"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -1,34 +1,5 @@
 #!/bin/bash
 
-# Fix hbb issues
-ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
-ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
-
-# Clang paths
-export CLANG_PREFIX="/opt/clang"
-export PATH=$PATH:$CLANG_PREFIX/bin
-
-# holy build box paths
-export HBB_PREFIX="/hbb_shlib"
-export PATH=$PATH:$HBB_PREFIX/bin:/hbb/bin
-export C_INCLUDE_PATH=$HBB_PREFIX/include
-export CPLUS_INCLUDE_PATH=$HBB_PREFIX/include
-export LIBRARY_PATH=$HBB_PREFIX/lib
-export PKG_CONFIG_PATH=$HBB_PREFIX/lib/pkgconfig:/usr/lib/pkgconfig
-
-export CPPFLAGS="-I$HBB_PREFIX/include"
-export LDPATHFLAGS="-L$HBB_PREFIX/lib"
-export MINIMAL_CFLAGS="-g -O3 $CPPFLAGS"
-
-export CFLAGS="$MINIMAL_CFLAGS"
-export CXXFLAGS="$MINIMAL_CFLAGS"
-export LDFLAGS="$LDPATHFLAGS -static-libstdc++"
-export STATICLIB_CFLAGS="$MINIMAL_CFLAGS -fPIC"
-export STATICLIB_CXXFLAGS="$MINIMAL_CFLAGS -fPIC"
-export SHLIB_CFLAGS="$MINIMAL_CFLAGS"
-export SHLIB_CXXFLAGS="$MINIMAL_CFLAGS"
-export SHLIB_LDFLAGS="$LDPATHFLAGS -static-libstdc++"
-
 # OpenMM paths
 CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"
 
@@ -38,6 +9,40 @@ CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=Release"
 CUDA_VERSION="8.0"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    #
+    # For Docker build
+    #
+
+    # Fix hbb issues
+    ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
+    ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
+
+    # Clang paths
+    export CLANG_PREFIX="/opt/clang"
+    export PATH=$PATH:$CLANG_PREFIX/bin
+
+    # holy build box paths
+    export HBB_PREFIX="/hbb_shlib"
+    export PATH=$PATH:$HBB_PREFIX/bin:/hbb/bin
+    export C_INCLUDE_PATH=$HBB_PREFIX/include
+    export CPLUS_INCLUDE_PATH=$HBB_PREFIX/include
+    export LIBRARY_PATH=$HBB_PREFIX/lib
+    export PKG_CONFIG_PATH=$HBB_PREFIX/lib/pkgconfig:/usr/lib/pkgconfig
+
+    export CPPFLAGS="-I$HBB_PREFIX/include"
+    export LDPATHFLAGS="-L$HBB_PREFIX/lib"
+    export MINIMAL_CFLAGS="-g -O3 $CPPFLAGS"
+
+    export CFLAGS="$MINIMAL_CFLAGS"
+    export CXXFLAGS="$MINIMAL_CFLAGS"
+    export LDFLAGS="$LDPATHFLAGS -static-libstdc++"
+    export STATICLIB_CFLAGS="$MINIMAL_CFLAGS -fPIC"
+    export STATICLIB_CXXFLAGS="$MINIMAL_CFLAGS -fPIC"
+    export SHLIB_CFLAGS="$MINIMAL_CFLAGS"
+    export SHLIB_CXXFLAGS="$MINIMAL_CFLAGS"
+    export SHLIB_LDFLAGS="$LDPATHFLAGS -static-libstdc++"
+
+    # OpenMM build configuration
     CUDA_PATH="/usr/local/cuda-${CUDA_VERSION}"
     CMAKE_FLAGS+=" -DCUDA_CUDART_LIBRARY=${CUDA_PATH}/lib64/libcudart.so"
     CMAKE_FLAGS+=" -DCUDA_NVCC_EXECUTABLE=${CUDA_PATH}/bin/nvcc"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
 # Fix hbb issues
-if [ ! -e /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ ]; then
-    ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
-fi
-if [ ! -e /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ ]; then
-    ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
-fi
+ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
+ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
 
 # Save anaconda path
 export PYTHON=`which python`

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -46,7 +46,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     CMAKE_FLAGS+=" -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_PATH}/"
     CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS=-I/usr/include/nvidia/"
     # Use clang 3.8.1 inside omnia-build-box docker image
-    CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+    CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=$CLANG_PREFIX/bin/clang -DCMAKE_CXX_COMPILER=$CLANG_PREFIX/bin/clang++"
     # AMD APP SDK 3.0 OpenCL
     CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=/opt/AMDAPPSDK-3.0/include/"
     CMAKE_FLAGS+=" -DOPENCL_LIBRARY=/opt/AMDAPPSDK-3.0/lib/x86_64/libOpenCL.so"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -4,13 +4,13 @@
 ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
 ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
 
-# Save anaconda path
-export PYTHON=`which python`
-export PYTHONBIN=`dirname $PYTHON`
+# Clang paths
+export CLANG_PREFIX="/opt/clang"
+export PATH=$PATH:$CLANG_PREFIX/bin
 
 # holy build box paths
 export HBB_PREFIX="/hbb_shlib"
-export PATH=$HBB_PREFIX/bin:/hbb/bin:$PATH
+export PATH=$PATH:$HBB_PREFIX/bin:/hbb/bin
 export C_INCLUDE_PATH=$HBB_PREFIX/include
 export CPLUS_INCLUDE_PATH=$HBB_PREFIX/include
 export LIBRARY_PATH=$HBB_PREFIX/lib
@@ -28,13 +28,6 @@ export STATICLIB_CXXFLAGS="$MINIMAL_CFLAGS -fPIC"
 export SHLIB_CFLAGS="$MINIMAL_CFLAGS"
 export SHLIB_CXXFLAGS="$MINIMAL_CFLAGS"
 export SHLIB_LDFLAGS="$LDPATHFLAGS -static-libstdc++"
-
-# Clang paths
-export CLANG_PREFIX="/opt/clang"
-export PATH=$CLANG_PREFIX/bin:$PATH
-
-# Add back anaconda path at front
-export PATH=$PYTHONBIN:$PATH
 
 # OpenMM paths
 CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+# Fix hbb issues
+ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/lib/gcc/x86_64-redhat-linux
+ln -s /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-CentOS-linux/ /opt/rh/devtoolset-2/root/usr/include/c++/4.8.2/x86_64-redhat-linux
+
+# holy build box paths
+export HBB_PREFIX="/hbb_shlib"
+export PATH=$HBB_PREFIX/bin:/hbb/bin:$PATH
+export C_INCLUDE_PATH=$HBB_PREFIX/include
+export CPLUS_INCLUDE_PATH=$HBB_PREFIX/include
+export LIBRARY_PATH=$HBB_PREFIX/lib
+export PKG_CONFIG_PATH=$HBB_PREFIX/lib/pkgconfig:/usr/lib/pkgconfig
+
+export CPPFLAGS="-I$HBB_PREFIX/include"
+export LDPATHFLAGS="-L$HBB_PREFIX/lib"
+export MINIMAL_CFLAGS="-g -O3 $CPPFLAGS"
+
+export CFLAGS="$MINIMAL_CFLAGS"
+export CXXFLAGS="$MINIMAL_CFLAGS"
+export LDFLAGS="$LDPATHFLAGS -static-libstdc++"
+export STATICLIB_CFLAGS="$MINIMAL_CFLAGS -fPIC"
+export STATICLIB_CXXFLAGS="$MINIMAL_CFLAGS -fPIC"
+export SHLIB_CFLAGS="$MINIMAL_CFLAGS"
+export SHLIB_CXXFLAGS="$MINIMAL_CFLAGS"
+export SHLIB_LDFLAGS="$LDPATHFLAGS -static-libstdc++"
+
+# Clang paths
+export CLANG_PREFIX="/opt/clang/bin/"
+export PATH=$CLANG_PREFIX/bin:$PATH
+
+# OpenMM paths
 CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"
 
 # Ensure we build a release
@@ -14,10 +44,16 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     CMAKE_FLAGS+=" -DCUDA_SDK_ROOT_DIR=${CUDA_PATH}/"
     CMAKE_FLAGS+=" -DCUDA_TOOLKIT_INCLUDE=${CUDA_PATH}/include"
     CMAKE_FLAGS+=" -DCUDA_TOOLKIT_ROOT_DIR=${CUDA_PATH}/"
-    CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS_RELEASE=-I/usr/include/nvidia/"
+    CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS=-I/usr/include/nvidia/"
+    # Use clang 3.8.1 inside omnia-build-box docker image
+    CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
     # AMD APP SDK 3.0 OpenCL
     CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=/opt/AMDAPPSDK-3.0/include/"
     CMAKE_FLAGS+=" -DOPENCL_LIBRARY=/opt/AMDAPPSDK-3.0/lib/x86_64/libOpenCL.so"
+    # Don't build tests or examples
+    CMAKE_FLAGS+=" -DOPENMM_BUILD_CUDA_TESTS=off"
+    CMAKE_FLAGS+=" -DOPENMM_BUILD_EXAMPLES=off"
+    CMAKE_FLAGS+=" -DOPENMM_BUILD_OPENCL_TESTS=off"
     # CUDA OpenCL
     #CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DUR=${CUDA_PATH}/include/"
     #CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${CUDA_PATH}/lib64/libOpenCL.so"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -10,7 +10,7 @@ fi
 
 # holy build box paths
 export HBB_PREFIX="/hbb_shlib"
-export PATH=$HBB_PREFIX/bin:/hbb/bin:$PATH
+export PATH=$PATH:$HBB_PREFIX/bin:/hbb/bin
 export C_INCLUDE_PATH=$HBB_PREFIX/include
 export CPLUS_INCLUDE_PATH=$HBB_PREFIX/include
 export LIBRARY_PATH=$HBB_PREFIX/lib
@@ -31,7 +31,7 @@ export SHLIB_LDFLAGS="$LDPATHFLAGS -static-libstdc++"
 
 # Clang paths
 export CLANG_PREFIX="/opt/clang"
-export PATH=$CLANG_PREFIX/bin:$PATH
+export PATH=$PATH:$CLANG_PREFIX/bin
 
 # OpenMM paths
 CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -30,7 +30,7 @@ export SHLIB_CXXFLAGS="$MINIMAL_CFLAGS"
 export SHLIB_LDFLAGS="$LDPATHFLAGS -static-libstdc++"
 
 # Clang paths
-export CLANG_PREFIX="/opt/clang/bin/"
+export CLANG_PREFIX="/opt/clang"
 export PATH=$CLANG_PREFIX/bin:$PATH
 
 # OpenMM paths

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -56,8 +56,8 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     CMAKE_FLAGS+=" -DOPENCL_LIBRARY=/opt/AMDAPPSDK-3.0/lib/x86_64/libOpenCL.so"
     # Don't build tests or examples
     CMAKE_FLAGS+=" -DOPENMM_BUILD_CUDA_TESTS=off"
-    CMAKE_FLAGS+=" -DOPENMM_BUILD_EXAMPLES=off"
     CMAKE_FLAGS+=" -DOPENMM_BUILD_OPENCL_TESTS=off"
+    #CMAKE_FLAGS+=" -DOPENMM_BUILD_EXAMPLES=off"
     # CUDA OpenCL
     #CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DUR=${CUDA_PATH}/include/"
     #CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${CUDA_PATH}/lib64/libOpenCL.so"
@@ -100,5 +100,7 @@ mv sphinx-docs/userguide/latex/*.pdf $PREFIX/docs/openmm/
 mv sphinx-docs/developerguide/latex/*.pdf $PREFIX/docs/openmm/
 
 # Put examples into an appropriate subdirectory.
-mkdir $PREFIX/share/openmm/
-mv $PREFIX/examples $PREFIX/share/openmm/
+if [ -d examples ]; then
+    mkdir $PREFIX/share/openmm/
+    mv $PREFIX/examples $PREFIX/share/openmm/
+fi

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -34,14 +34,14 @@ requirements:
     - python
     - fftw3f
 
-test:
-  requires:
-    - python
-  imports:
-    - simtk
-    - simtk.openmm
-  commands:
-    - python -m simtk.testInstallation
+#test:
+#  requires:
+#    - python
+#  imports:
+#    - simtk
+#    - simtk.openmm
+#  commands:
+#    - python -m simtk.testInstallation
 
 about:
   home: http://openmm.org


### PR DESCRIPTION
@peastman @mpharrigan: I've been combining all of the fixes suggested to build the openmm 7.1 beta, but have run into a bizarre glibc segfault when building the python wrappers. Backtrace attached.

[backtrace.txt](https://github.com/omnia-md/conda-dev-recipes/files/662810/backtrace.txt)

To replicate, first start docker:
```bash
docker run -i -t jchodera/omnia-build-box:cuda80-amd30-clang38 /bin/bash
```
Then build inside the docker image:
```bash
# First, the boilerplate from devtools/docker-build.sh to mimic what conda-recipes does
source /hbb_exe/activate
unset PYTHONPATH
set -x
curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
PATH=/opt/rh/devtoolset-2/root/usr/bin:/opt/rh/autotools-latest/root/usr/bin:/anaconda/bin:$PATH
conda config --add channels omnia
conda install -yq conda-build==2.0.1 jinja2 anaconda-client

# Clone conda-dev-recipes
git clone https://github.com/omnia-md/conda-dev-recipes.git
cd conda-dev-recipes; git checkout openmm-7.1-beta; git pull origin openmm-7.1-beta ; cd /

# Build conda package
wget -O conda-build-all --no-check-certificate --quiet https://raw.githubusercontent.com/omnia-md/conda-recipes/master/conda-build-all
chmod u+x conda-build-all
./conda-build-all -vvv --dev --force -- /conda-dev-recipes/openmm || true

# Upload package to anaconda cloud
#anaconda upload --force --label beta --channel omnia --user omnia /anaconda/conda-bld/linux-64/openmm-7.1.0-py* || true
```