### PR TITLE
Don't pin conda-build to 2.0.1 now that conda-recipes conda-build-all has been unpinned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ services:
 env:
 env:
   global:
-    - CONDA_BUILD: "2.0.1"
     - CUDA_VERSION: "8.0"
     - CUDA_SHORT_VERSION: "80"
   secure:
@@ -41,7 +40,7 @@ script:
   - echo $UPLOAD
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
-        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST -e CONDA_BUILD
+        docker run -e UPLOAD -e BINSTAR_TOKEN -e TRAVIS_PULL_REQUEST
             -t -i --rm -v `pwd`:/io jchodera/omnia-build-box:cuda${CUDA_SHORT_VERSION}-amd30-clang38
             bash /io/devtools/docker-build.sh;
 

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -11,7 +11,7 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
 PATH=/opt/rh/devtoolset-2/root/usr/bin:/opt/rh/autotools-latest/root/usr/bin:/anaconda/bin:$PATH
 conda config --add channels omnia
-conda install -yq conda-build=$CONDA_BUILD jinja2 anaconda-client
+conda install -yq conda-build jinja2 anaconda-client
 
 if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
     /io/conda-build-all -vvv $UPLOAD -- /io/* || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -11,7 +11,7 @@ curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.s
 bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
-conda install -yq conda-build=$CONDA_BUILD  jinja2 anaconda-client;
+conda install -yq conda-build jinja2 anaconda-client;
 
 # Install OpenMM dependencies that can't be installed through
 # conda package manager (doxygen + CUDA)


### PR DESCRIPTION
cc: https://github.com/omnia-md/conda-recipes/pull/671