### PR TITLE
Switch back to uploading openmm dev package as 7.2.0

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openmm
-  version: 7.3.0
+  version: 7.2.0
 
 source:
   git_url: https://github.com/pandegroup/openmm.git


### PR DESCRIPTION
We had previously been uploading the `openmm` `dev` label packages built with the `omnia-linux-anvil` as 7.3.0 so we could compare with those built with `omnia-build-box` as 7.2.0.

This PR will now label `omnia-linux-anvil` builds as 7.2.0.

I will manually remove the 7.3.0 builds from `omnia` after the 7.2.0 builds post.