### PR TITLE
Cleanup Conda Forge settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Packages are built twice daily by [the Travis CI cron trigger](http://traviscron
 To install a development package
 ```
 # Add the omnia and conda-forge
-$ conda config --add channels conda-forge --add channels omnia
+$ conda config --add channels omnia --add channels conda-forge
 
 conda install openmm-dev
 ```
@@ -31,10 +31,10 @@ two releases of Numpy.
 ### Building the packages
 
 The recipes here are automatically built using [Appveyor-CI](http://www.appveyor.com/)
-and [Travis-CI](https://travis-ci.org/). For linux, we use the
-[Holy Build Box](http://phusion.github.io/holy-build-box/) to ensure that the
-packages are fully compatible accross multiple linux distributions and versions.
+and [Travis-CI](https://travis-ci.org/). For linux, we use a modified
+[Conda-forge Linux Anvil](https://github.com/conda-forge/docker-images/tree/master/linux-anvil) to ensure that the
+packages are fully compatible across multiple linux distributions and versions.
 
 To build a package yourself, run `conda build <package_name>`, or
-`./conda-build-all ./*` to build multiple packages accross each of the
+`./conda-build-all ./*` to build multiple packages across each of the
 supported Python/Numpy configurations.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,18 +18,20 @@ environment:
       CONDA_PY: "27"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Miniconda-x64"
       CONDA_PY: "27"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Miniconda3"
-      CONDA_PY: "34"
-      PYTHON_VERSION: "3.4.x"
+      CONDA_PY: "35"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Miniconda3-x64"
-      CONDA_PY: "34"
-      PYTHON_VERSION: "3.4.x"
+      CONDA_PY: "35"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Miniconda3"
@@ -38,17 +40,16 @@ environment:
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Miniconda3-x64"
-      CONDA_PY: "35"
-      PYTHON_VERSION: "3.5.x"
+      CONDA_PY: "36"
+      PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - conda update -yq --all
-  - conda config --set channel_priority false
-  - conda config --add channels conda-forge
-  - conda config --add channels omnia
   - conda install -yq conda-build jinja2 anaconda-client
+  - conda config --add channels omnia
+  - conda config --add channels conda-forge
   - powershell .\\devtools\\appveyor\\missing-headers.ps1
   # conda-build for some inane reason, effectively puts C:\cygwin\bin at the
   # front of the PATH, ahead of everything else, regardless. See

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -e
 set -x
-conda config --set channel_priority false
 conda config --add channels omnia
-conda install -yq conda-build jinja2 anaconda-client
+# Move the conda-forge channel to the top
+# Cannot just append omnia otherwise default would have higher priority
+conda config --add channels conda-forge
+conda install -yq conda\>=4.3 conda-build jinja2 anaconda-client
 
 /io/conda-build-all -vvv --python $PY_BUILD_VERSION $UPLOAD -- /io/*
 

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -10,9 +10,9 @@ brew tap -y caskroom/cask
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
 bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/anaconda;
 export PATH=$HOME/anaconda/bin:$PATH;
-conda config --add channels conda-forge;
 conda config --add channels omnia;
-conda config --set channel_priority false;
+conda config --add channels conda-forge;
+conda install -yq conda\>=4.3 conda-env conda-build jinja2 anaconda-client;
 conda config --show;
 conda install -yq conda conda-build jinja2 anaconda-client;
 

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -14,7 +14,6 @@ conda config --add channels omnia;
 conda config --add channels conda-forge;
 conda install -yq conda\>=4.3 conda-env conda-build jinja2 anaconda-client;
 conda config --show;
-conda install -yq conda conda-build jinja2 anaconda-client;
 
 
 #export INSTALL_CUDA=`./conda-build-all --dry-run -- openmm`


### PR DESCRIPTION
We made some changes to how we specify conda channels in omnia-md/conda-recipes#778, this PR updates this repo to reflect those changes:

* Made conda-forge top priority channel, omnia second
* Removed --no-chan-pri requirement
* Updated README to reflect changes
* Drops support for Python 3.4
* Addds Python 3.6 support