### PR TITLE
Add openmmforcefields test builds

### DIFF
--- a/openmmforcefields/bld.bat
+++ b/openmmforcefields/bld.bat
@@ -1,0 +1,2 @@
+%PYTHON% setup.py install
+if errorlevel 1 exit 1

--- a/openmmforcefields/build.sh
+++ b/openmmforcefields/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/openmmforcefields/meta.yaml
+++ b/openmmforcefields/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: openmmforcefields
+  version: 0.0.0
+
+source:
+  git_url: https://github.com/choderalab/openmm-forcefields.git
+
+build:
+  preserve_egg_dir: True
+  number: 0
+
+requirements:
+  build:
+    - python
+    - openmm >=7.2.0
+
+  run:
+    - python
+    - openmm >=7.2.0
+
+test:
+  requires:
+    - nose
+    - nose-timer
+  imports:
+    - openmmforcefields
+
+about:
+  home: https://github.com/choderalab/openmm-forcefields
+  license: MIT License


### PR DESCRIPTION
The `openmmforcefields` package requires `openmm >= 7.2.0`, so I need to build it here.