### PR TITLE
Pin OpenMM to non-segfaulty version

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -4,7 +4,8 @@ package:
 
 source:
   git_url: https://github.com/pandegroup/openmm.git
-
+  git_tag: 18a7cac0e14789756429d4dd6418553adc36c844
+  
 build:
   number: 0
   skip: True # [win]


### PR DESCRIPTION
This pins `openmm` to `18a7cac0e14789756429d4dd6418553adc36c844`, which is before https://github.com/pandegroup/openmm/pull/1870 was merged.