### PR TITLE
Enable the OSX cache for the CUDA installers 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,14 @@ sudo: required
 services:
   - docker
 
+cache:
+  directories:
+    # Disabled homebrew cache, did not appear to do anything
+    #- $HOME/Library/Caches/Homebrew
+    - $HOME/nvidia_cache
+  # https://docs.travis-ci.com/user/caching/#Setting-the-timeout
+  timeout: 900  # seconds: 15 min cache upload time (default is 3 min)
+
 env:
   matrix:
     - PY_BUILD_VERSION="27"
@@ -48,6 +56,7 @@ script:
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 
         echo "Building osx...";
+        export NVIDIA_CACHE=$HOME/nvidia_cache;
         bash devtools/osx-build.sh;
 
     fi

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e -x
 export MACOSX_DEPLOYMENT_TARGET="10.9"
-# Update homebrew
-brew uninstall -y brew-cask || brew untap -y caskroom/cask || 1
-brew update -y --quiet
-brew tap -y caskroom/cask
+# Clear existing locks
+rm -rf /usr/local/var/homebrew/locks
+# Update homebrew cant disable this yet, -y and --quiet do nothing
+brew update
 
 # Install Miniconda
 curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
@@ -25,11 +25,22 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
     # Install OpenMM dependencies that can't be installed through
     # conda package manager (doxygen + CUDA)
     brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb
-    curl -O -s http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
-    curl -O -s http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
+    # Make the nvidia-cache if not there
+    mkdir -p $NVIDIA_CACHE
+    cd $NVIDIA_CACHE
+    # Download missing nvidia installers
+    if ! [ -f cuda_mac_installer_tk.tar.gz ]; then
+        curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_tk.tar.gz
+    fi
+    if ! [ -f cuda_mac_installer_drv.tar.gz ]; then
+        curl -O -# http://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/network_installers/mac/x86_64/cuda_mac_installer_drv.tar.gz
+    fi
     sudo tar -zxf cuda_mac_installer_tk.tar.gz -C /;
     sudo tar -zxf cuda_mac_installer_drv.tar.gz -C /;
-    rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
+    # Don't delete the tarballs to cache the package
+    # rm -f cuda_mac_installer_tk.tar.gz cuda_mac_installer_drv.tar.gz
+    # Now head back to work directory
+    cd $TRAVIS_BUILD_DIR
 
     # Install latex.
     export PATH="/usr/texbin:${PATH}:/usr/bin"


### PR DESCRIPTION
Try and speed up the osx build times, this reflects the changes made to the main conda-recipes channel.

cc @jchodera 