### PR TITLE
Re-split python build versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ services:
   - docker
 
 env:
+  matrix:
+    - PY_BUILD_VERSION="27"
+    - PY_BUILD_VERSION="35"
+    - PY_BUILD_VERSION="36"
   global:
     - CUDA_VERSION: "9.0"
     - CUDA_SHORT_VERSION: "90"

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -9,6 +9,6 @@ conda update -yq --all
 conda config --add channels omnia/label/dev
 conda install -yq conda-build==2.1.17 jinja2 anaconda-client
 
-/io/conda-build-all -vvv $UPLOAD -- /io/*
+/io/conda-build-all -vvv --python $PY_BUILD_VERSION $UPLOAD -- /io/*
 
 #mv /anaconda/conda-bld/linux-64/*tar.bz2 /io/ || true

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -13,6 +13,7 @@ export PATH=$HOME/anaconda/bin:$PATH;
 conda config --add channels omnia;
 conda config --add channels conda-forge;
 conda update -yq --all;
+conda config --add channels omnia/label/dev
 conda install -yq conda-env conda-build==2.1.7 jinja2 anaconda-client;
 conda config --show;
 
@@ -59,4 +60,4 @@ if [ "$INSTALL_OPENMM_PREREQUISITES" = true ] ; then
 fi;
 
 # Build packages
-./conda-build-all -v $UPLOAD -- *
+./conda-build-all -vvv --python $PY_BUILD_VERSION $UPLOAD -- *


### PR DESCRIPTION
Partial revert of #117 where the python version were recombined in .travis.yml, resulting in a timeout.

This leaves in place the call to use the old docker image, which should have been the major fix needed for the travis builds.

cc @jchodera 