### PR TITLE
Set OpenMM to use Cuda 9.1 image

### DIFF
--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -5,7 +5,7 @@ CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"
 # Ensure we build a release
 CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=Debug"
 
-CUDA_VERSION="9.0"
+CUDA_VERSION="9.1"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     #


### PR DESCRIPTION
Missed a flag in the OpenMM `build.sh` file which pointed to the CUDA 9.0 image, which does not exist right now since we build with 9.1

cc @jchodera