### PR TITLE
Push OpenMM to different CUDA labels

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -5,14 +5,16 @@ package:
 source:
   git_url: https://github.com/pandegroup/openmm.git
 
+extra:
+  upload: cuda{{ CUDA_SHORT_VERSION }}
 
 build:
   number: 0
   skip: True # [win]
   detect_binary_files_with_prefix: False
-  string: py{{py}}_cuda{{ CUDA_SHORT_VERSION }}_0
-  features:
-    - cuda{{ CUDA_SHORT_VERSION }}
+  string: py{{py}}_cuda{{ CUDA_SHORT_VERSION }}_1
+  #features:
+  #  - cuda{{ CUDA_SHORT_VERSION }}
 
 requirements:
   build:


### PR DESCRIPTION
This PR attempts to build OpenMM for different CUDA versions, uploading them to `cudaXY` labels on anaconda cloud.

cc: https://github.com/pandegroup/openmm/issues/2084#issuecomment-401618239

