### PR TITLE
[WIP] Enable openmm build options that check for memory and thread issues

### DIFF
--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -2,8 +2,11 @@
 
 CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"
 
-# Ensure we build a release
+# Ensure we build a debug version
 CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=Debug"
+
+# Don't build static
+CMAKE_FLAGS+=" -DOPENMM_BUILD_STATIC_LIB=OFF"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     #

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -15,8 +15,9 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     env
 
     # CFLAGS
-    #export MINIMAL_CFLAGS="-g -O3"
-    export MINIMAL_CFLAGS="-g -O1 -Wthread-safety -fsanitize=address -fsanitize=thread -fsanitize=memory -fsanitize=signed-integer-overflow,null,alignment -fsanitize=leak -fno-omit-frame-pointer -fsanitize-memory-track-origins -fsanitize-memory-use-after-dtor -fsanitize-address-use-after-scope -fsanitize-stats" # DEBUG
+    #export MINIMAL_CFLAGS="-g -O3 -Wthread-safety"
+    #export MINIMAL_CFLAGS="-g -O1 -fsanitize=address -fno-optimize-sibling-calls"
+    export MINIMAL_CFLAGS="-g -O1 -fsanitize=memory -fno-omit-frame-pointer"
     export CFLAGS="$MINIMAL_CFLAGS"
     export CXXFLAGS="$MINIMAL_CFLAGS"
     export LDFLAGS="$LDPATHFLAGS"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -5,10 +5,6 @@ CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"
 # Ensure we build a debug version
 CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=Debug"
 
-# Don't build static
-CMAKE_FLAGS+=" -DOPENMM_BUILD_STATIC_LIB=OFF -DOPENMM_BUILD_SHARED_LIB=ON"
-CMAKE_FLAGS+=" -DCMAKE_LINKER=clang -DCMAKE_CXX_LINK_EXECUTABLE=clang++"
-
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     #
     # For Docker build
@@ -21,7 +17,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     # CFLAGS
     #export MINIMAL_CFLAGS="-g -O3 -Wthread-safety"
     #export MINIMAL_CFLAGS="-g -O1 -fsanitize=address -fno-optimize-sibling-calls"
-    export MINIMAL_CFLAGS="-g -O1 -fsanitize=memory -fno-omit-frame-pointer"
+    export MINIMAL_CFLAGS="-g -O1 -fsanitize=memory -fno-omit-frame-pointer" # DEBUG: Check memory is properly initialized
     export CFLAGS="$MINIMAL_CFLAGS"
     export CXXFLAGS="$MINIMAL_CFLAGS"
     export LDFLAGS="$LDPATHFLAGS"
@@ -41,8 +37,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     #CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DUR=${CUDA_PATH}/include/"
     #CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${CUDA_PATH}/lib64/libOpenCL.so"
     # gcc from devtoolset-2
-    #CMAKE_FLAGS+=" -DCMAKE_CXX_LINK_FLAGS=-Wl,-rpath,/opt/rh/devtoolset-2/root/usr/lib64" # JDC test
-    #CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS=--gcc-toolchain=/opt/rh/devtoolset-2/root/usr/" # DEBUG
+    CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS=--gcc-toolchain=/opt/rh/devtoolset-2/root/usr/"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # conda-build MACOSX_DEPLOYMENT_TARGET must be exported as an environment variable to override 10.7 default
     # cc: https://github.com/conda/conda-build/pull/1561

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -15,10 +15,13 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     env
 
     # CFLAGS
-    export MINIMAL_CFLAGS="-g -O3"
+    #export MINIMAL_CFLAGS="-g -O3"
+    export MINIMAL_CFLAGS="-g -O1 -Wthread-safety -fsanitize=address -fsanitize=thread -fsanitize=memory -fsanitize=signed-integer-overflow,null,alignment -fsanitize=leak -fno-omit-frame-pointer -fsanitize-memory-track-origins -fsanitize-memory-use-after-dtor -fsanitize-address-use-after-scope -fsanitize-stats" # DEBUG
     export CFLAGS="$MINIMAL_CFLAGS"
     export CXXFLAGS="$MINIMAL_CFLAGS"
     export LDFLAGS="$LDPATHFLAGS"
+
+
 
     # Use clang 3.8.1 from the clangdev package on conda-forge
     CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -6,7 +6,8 @@ CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_TESTING=OFF"
 CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=Debug"
 
 # Don't build static
-CMAKE_FLAGS+=" -DOPENMM_BUILD_STATIC_LIB=OFF"
+CMAKE_FLAGS+=" -DOPENMM_BUILD_STATIC_LIB=OFF -DOPENMM_BUILD_SHARED_LIB=ON"
+CMAKE_FLAGS+=" -DCMAKE_LINKER=clang -DCMAKE_CXX_LINK_EXECUTABLE=clang++"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     #
@@ -68,7 +69,9 @@ fi
 # Build in subdirectory and install.
 mkdir build
 cd build
+set # DEBUG
 cmake .. $CMAKE_FLAGS
+cat CMakeCache.txt # DEBUG
 make -j$CPU_COUNT all
 
 # PythonInstall uses the gcc/g++ 4.2.1 that anaconda was built with, so we can't add extraneous unrecognized compiler arguments.

--- a/openmm/build.sh
+++ b/openmm/build.sh
@@ -42,7 +42,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     #CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${CUDA_PATH}/lib64/libOpenCL.so"
     # gcc from devtoolset-2
     #CMAKE_FLAGS+=" -DCMAKE_CXX_LINK_FLAGS=-Wl,-rpath,/opt/rh/devtoolset-2/root/usr/lib64" # JDC test
-    CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS=--gcc-toolchain=/opt/rh/devtoolset-2/root/usr/"
+    #CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS=--gcc-toolchain=/opt/rh/devtoolset-2/root/usr/" # DEBUG
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # conda-build MACOSX_DEPLOYMENT_TARGET must be exported as an environment variable to override 10.7 default
     # cc: https://github.com/conda/conda-build/pull/1561

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - lxml
     - numpy
     # Get clang from conda-forge
-    - clangdev ==6.0.0 [linux]
+    - clangdev ==7.0.0 [linux]
     # Required for sphinx
     - latexmk
 

--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_url: https://github.com/pandegroup/openmm.git
 
   patches:
-    - silent-cmake.patch
+    #- silent-cmake.patch
     - silent-doxygen.patch
     - silent-latexpdf.patch
 


### PR DESCRIPTION
This attempts to use some options of `clang` to check for runtime issues with memory and threads.