### PR TITLE
Restore tests to ensure openmm is packaged correctly

### DIFF
--- a/openmm/meta.yaml
+++ b/openmm/meta.yaml
@@ -57,15 +57,14 @@ requirements:
     - numpy
     - cython
 
-#test:
-#  requires:
-#    - python
-#    - cuda{{ CUDA_SHORT_VERSION }}
-#  imports:
-#    - simtk
-#    - simtk.openmm
-#  commands:
-#    - python -m simtk.testInstallation
+test:
+  requires:
+    - python
+  imports:
+    - simtk
+    - simtk.openmm
+  commands:
+    - python -m simtk.testInstallation
 
 about:
   home: http://openmm.org


### PR DESCRIPTION
This restores some quick tests to the conda recipe to ensure the OpenMM package is being built correctly. This should catch any issues earlier next time.