### PR TITLE
Updated dependencies for openforcefield toolkit.

### DIFF
--- a/openforcefield/meta.yaml
+++ b/openforcefield/meta.yaml
@@ -26,13 +26,12 @@ requirements:
     - networkx >=2.0
     - lxml
     - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
+    - openmm
     - packaging
     # Should these be optional?
     - rdkit
     - ambertools
     #- parmed # uncomment when new ambermini (without parmed) is built
-    # Should we require this? It's useful for tests and examples, but not strictly required
-    - openmmtools # If we remove this we need to install openmm (which minimum version?)
     # Serialization: Should these be optional?
     - pyyaml
     - toml

--- a/openforcefield/meta.yaml
+++ b/openforcefield/meta.yaml
@@ -13,7 +13,8 @@ build:
 
 extra:
   force_upload: True
-  
+  upload: main
+
 requirements:
   build:
     - python
@@ -25,9 +26,19 @@ requirements:
     - networkx >=2.0
     - lxml
     - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
+    - packaging
+    # Should these be optional?
     - rdkit
     - ambertools
     #- parmed # uncomment when new ambermini (without parmed) is built
+    # Should we require this? It's useful for tests and examples, but not strictly required
+    - openmmtools # If we remove this we need to install openmm (which minimum version?)
+    # Serialization: Should these be optional?
+    - pyyaml
+    - toml
+    - bson
+    - msgpack-python
+    - xmltodict
 
 test:
   requires:


### PR DESCRIPTION
Fix some of the dependencies for the conda dev package. I've also added the `extra.upload: main` to fix the label of the anaconda package.

I've mostly taken the dependencies from [this conda recipe](https://github.com/openforcefield/openforcefield/blob/84487d9ced489d9d354c00459c16931f3abbb68e/devtools/conda-recipe/meta.yaml) from the `openforcefield/openforcefield` repo.

The main question is: should we remove some of the optional packages? Installing a fresh conda environment using [this recipe](https://github.com/omnia-md/conda-recipes/blob/2de9a1fcd9f8731a58d99422c0d1d0f9f1c25dcf/openforcefield/meta.yaml) on `omnia-md/conda-recipes` took several minutes with the CPU under a heavy workload with my MacBook Pro so if we're planning to have a hands-on session in which people would like to install everything we may need to strip the recipe down to a bare minimum.