### PR TITLE
Reorder Python build order to "37" "36" "35" "27"

### DIFF
--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -101,7 +101,7 @@ conda config --add channels omnia/label/betacuda${CUDA_SHORT_VERSION};
 #conda config --add channels omnia/label/dev;
 #conda config --add channels omnia/label/devcuda${CUDA_SHORT_VERSION};
 
-for PY_BUILD_VERSION in "27" "35" "36" "37"; do
+for PY_BUILD_VERSION in "37" "36" "35" "27" ; do
 #for PY_BUILD_VERSION in "37" "36" "35" "27"; do
     ./conda-build-all -vvv --python $PY_BUILD_VERSION --check-against omnia/label/beta --check-against omnia/label/betacuda${CUDA_SHORT_VERSION} --check-against omnia/label/dev --check-against omnia/label/devcuda${CUDA_SHORT_VERSION} --numpy "1.15" $UPLOAD -- *
 done


### PR DESCRIPTION
@peastman: Are we intending to keep supporting either 2.7 or 3.5 for very long?