### PR TITLE
Unpin conda-build in Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -145,8 +145,7 @@ jobs:
     # This is supposedly deprecated, but this is still required for Microsoft-hosted agents to use the conda env
     - task: CondaEnvironment@1
       inputs:
-        # TODO: Remove CB pin once PREFIX hardcoding has been fixed for Windows
-        packageSpecs: 'python=3 conda-build=3.18.11 conda anaconda-client'
+        packageSpecs: 'python=3 conda-build conda anaconda-client'
         installOptions: "-c conda-forge"
         updateConda: false
       displayName: Install conda-build and activate environment


### PR DESCRIPTION
Conda Build 3.19.1 allegedly fixes the `PREFIX` replacement issues reported in #186. Let's see if it's true!