### PR TITLE
Fix Windows builds

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -9,7 +9,8 @@ c_compiler:
   - clang                      # [osx]
   - vs2017                     # [win]
 c_compiler_version:            # [unix]
-  - 10                         # [osx]
+  - 11                         # [osx and arm64]
+  - 10                         # [osx and x86_64]
   - 7                          # [linux64 or aarch64]
   - 8                          # [ppc64le or armv7l]
 cxx_compiler:
@@ -17,15 +18,16 @@ cxx_compiler:
   - clangxx                    # [osx]
   - vs2017                     # [win]
 cxx_compiler_version:          # [unix]
-  - 10                         # [osx]
+  - 11                         # [osx and arm64]
+  - 10                         # [osx and x86_64]
   - 7                          # [linux64 or aarch64]
   - 8                          # [ppc64le or armv7l]
 fortran_compiler:              # [unix or win64]
-  - gfortran                   # [(linux64 or osx)]
+  - gfortran                   # [linux64 or (osx and x86_64)]
   - gfortran                   # [aarch64 or ppc64le or armv7l]
   - flang                      # [win64]
 fortran_compiler_version:      # [unix or win64]
-  - 7                          # [linux64 or osx or aarch64]
+  - 7                          # [linux64 or (osx and x86_64) or aarch64]
   - 8                          # [ppc64le or armv7l]
   - 5                          # [win64]
 m2w64_c_compiler:              # [win]
@@ -80,17 +82,27 @@ rust_compiler_version:
 
 
 macos_min_version:             # [osx]
-  - 10.9                       # [osx]
+  - 11.0                       # [osx and arm64]
+  - 10.9                       # [osx and x86_64]
 macos_machine:                 # [osx]
-  - x86_64-apple-darwin13.4.0  # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - arm64-apple-macos11        # [osx and arm64]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
-  - 10.9                       # [osx]
+  - 11.0                       # [osx and arm64]
+  - 10.9                       # [osx and x86_64]
 target_platform:               # [win]
   - win-64                     # [win]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
   - VERBOSE=1
+
+# dual build configuration
+channel_sources:
+  - conda-forge,defaults                        # [not (aarch64 or armv7l or (osx and arm64))]
+  - conda-forge/label/llvm_rc,conda-forge       # [osx and arm64]
+  - conda-forge                                 # [aarch64]
+  - conda-forge,c4armv7l,defaults               # [armv7l]
 
 # aarch64 specifics because conda-build sets many things to centos 6
 # this can probably be removed when conda-build gets updated defaults
@@ -363,7 +375,7 @@ glpk:
 gmp:
   - 6
 google_cloud_cpp:
-  - '1.15'
+  - '1.16'
 google_cloud_cpp_common:
   - 0.25.0
 googleapis_cpp:
@@ -382,7 +394,7 @@ hdf5:
 icu:
   - 64.2
 isl:
-  - 0.19
+  - '0.22'
 jasper:
   - 1.900.1
 jpeg:
@@ -443,6 +455,8 @@ libtiff:
   - 4.1.0
 libunwind:
   - 1.2
+libv8:
+  - 8.4.371
 libwebp:
   - 1.1
 libwebp_base:
@@ -489,8 +503,7 @@ ntl:
   - '11.4.3'
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
-  - 1.14       # [not (aarch64 or ppc64le)]
-  - 1.16       # [aarch64 or ppc64le]
+  - 1.16
 occt:
   - 7.4
 openblas:
@@ -522,7 +535,7 @@ pixman:
 poppler:
   - 0.67.0
 proj:
-  - 7.0.0
+  - 7.1.0
 python:
   - 3.6.* *_cpython
   - 3.7.* *_cpython
@@ -532,7 +545,7 @@ python_impl:
 qt:
   - 5.12
 re2:
-  - 2020.07.06
+  - 2020.08.01
 readline:
   - 8.0
 rocksdb:
@@ -565,7 +578,7 @@ suitesparse:
 tk:
   - 8.6                # [not ppc64le]
 tiledb:
-  - 1.7
+  - '2.0'
 uhd:
   - 3.15.0
 vc:                    # [win]


### PR DESCRIPTION
There's a conflict with `archspec` that we might be able to solve with a `conda_build_config.yaml` update. Otherwise it might be one of those "freeze/unfreeze conda (build)" issues.