### PR TITLE
Pin conda build to <=3.20.4

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -165,7 +165,7 @@ jobs:
       # This is supposedly deprecated, but this is still required for Microsoft-hosted agents to use the conda env
       - task: CondaEnvironment@1
         inputs:
-          packageSpecs: "python=3.7 conda-build>=3.19.2 conda anaconda-client"
+          packageSpecs: "python=3.7 'conda-build>=3.19.2,<=3.20.4' conda anaconda-client"
           installOptions: "-c conda-forge"
           updateConda: false
         displayName: Install conda-build and activate environment

--- a/devtools/docker-build.sh
+++ b/devtools/docker-build.sh
@@ -18,7 +18,7 @@ CONDARC
 conda config --add channels omnia
 conda config --add channels conda-forge
 
-conda install --yes conda conda-build anaconda-client
+conda install --yes conda 'conda-build>=3.19.2,<=3.20.4' anaconda-client
 
 conda config --set show_channel_urls true
 conda config --set auto_update_conda false

--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -15,7 +15,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes conda-forge-ci-setup=3 'conda-build>=3.19.2,<=3.20.4' pip
 
 echo -e "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./recipe ./.conda_configs/${CONFIG}.yaml


### PR DESCRIPTION
3.20.5 introduces https://github.com/conda/conda-build/pull/4086/files, which breaks `conda-build-all` due to a new position argument that we are not supplying:

```
% /io/conda-build-all -vvv --no-build-jinja CUDA_STR --scheduled-only --upload omnia-dev --force -m /conda_configs/python3.6.yaml -- /io/recipes/openmm/
command-line arguments:
Namespace(build_only_jinja=None, check_against=['omnia/label/main', 'omnia/label/dev', 'omnia/label/rc', 'omnia/label/beta'], clean_tarballs=False, cycle=False, debug=False, dev=False, dry_run=False, force=True, no_build_jinja=['CUDA_STR'], notest=False, rebuild=False, recipe=['/io/recipes/openmm/'], scheduled_only=True, upload='omnia-dev', variant_config_files=['/conda_configs/python3.6.yaml'], verbose=3)
Traceback (most recent call last):
  File "/io/conda-build-all", line 750, in <module>
    sys.exit(main())
  File "/io/conda-build-all", line 746, in main
    return execute(args)
  File "/io/conda-build-all", line 538, in execute
    variant_config_files = fcf('.')
TypeError: find_config_files() missing 1 required positional argument: 'config'
```

Fix wouldn't be too complicated but I'll just pin to 3.20.4 for now.