### PR TITLE
Update CUDA versions to match conda-forge deployment

### DIFF
--- a/.conda_configs/gen_confs.py
+++ b/.conda_configs/gen_confs.py
@@ -9,8 +9,8 @@ import re
 import ruamel_yaml  # This gets installed with conda-build
 
 
-PYTHONS = ["3.6.* *_cpython", "3.7.* *_cpython", "3.8.* *_cpython", "3.9.* *_cpython"]
-CUDAS = [8.0, 9.0, 9.1, 9.2, 10.0, 10.1, 10.2, 11.0]
+PYTHONS = ["3.7.* *_cpython", "3.8.* *_cpython", "3.9.* *_cpython"]
+CUDAS = [10.2, 11.0, 11.1, 11.2]
 
 dumper_keys = {"indent": 4, "block_seq_indent": 2}
 dumper = ruamel_yaml.round_trip_dump

--- a/.conda_configs/python3.7_cuda10.0.yaml
+++ b/.conda_configs/python3.7_cuda10.0.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.7.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 100
-
-CUDA_VERSION:
-  - 10.0

--- a/.conda_configs/python3.7_cuda10.1.yaml
+++ b/.conda_configs/python3.7_cuda10.1.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.7.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 101
-
-CUDA_VERSION:
-  - 10.1

--- a/.conda_configs/python3.7_cuda11.1.yaml
+++ b/.conda_configs/python3.7_cuda11.1.yaml
@@ -2,7 +2,7 @@ python:
   - 3.7.* *_cpython
 
 CUDA_SHORT_VERSION:
-  - 80
+  - 111
 
 CUDA_VERSION:
-  - 8.0
+  - 11.1

--- a/.conda_configs/python3.7_cuda11.2.yaml
+++ b/.conda_configs/python3.7_cuda11.2.yaml
@@ -1,8 +1,8 @@
 python:
-  - 3.8.* *_cpython
+  - 3.7.* *_cpython
 
 CUDA_SHORT_VERSION:
-  - 90
+  - 112
 
 CUDA_VERSION:
-  - 9.0
+  - 11.2

--- a/.conda_configs/python3.7_cuda9.0.yaml
+++ b/.conda_configs/python3.7_cuda9.0.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.7.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 90
-
-CUDA_VERSION:
-  - 9.0

--- a/.conda_configs/python3.7_cuda9.2.yaml
+++ b/.conda_configs/python3.7_cuda9.2.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.7.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 92
-
-CUDA_VERSION:
-  - 9.2

--- a/.conda_configs/python3.8_cuda10.0.yaml
+++ b/.conda_configs/python3.8_cuda10.0.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.8.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 100
-
-CUDA_VERSION:
-  - 10.0

--- a/.conda_configs/python3.8_cuda10.1.yaml
+++ b/.conda_configs/python3.8_cuda10.1.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.8.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 101
-
-CUDA_VERSION:
-  - 10.1

--- a/.conda_configs/python3.8_cuda11.1.yaml
+++ b/.conda_configs/python3.8_cuda11.1.yaml
@@ -1,8 +1,8 @@
 python:
-  - 3.7.* *_cpython
+  - 3.8.* *_cpython
 
 CUDA_SHORT_VERSION:
-  - 91
+  - 111
 
 CUDA_VERSION:
-  - 9.1
+  - 11.1

--- a/.conda_configs/python3.8_cuda11.2.yaml
+++ b/.conda_configs/python3.8_cuda11.2.yaml
@@ -2,7 +2,7 @@ python:
   - 3.8.* *_cpython
 
 CUDA_SHORT_VERSION:
-  - 80
+  - 112
 
 CUDA_VERSION:
-  - 8.0
+  - 11.2

--- a/.conda_configs/python3.8_cuda9.1.yaml
+++ b/.conda_configs/python3.8_cuda9.1.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.8.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 91
-
-CUDA_VERSION:
-  - 9.1

--- a/.conda_configs/python3.8_cuda9.2.yaml
+++ b/.conda_configs/python3.8_cuda9.2.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.8.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 92
-
-CUDA_VERSION:
-  - 9.2

--- a/.conda_configs/python3.9_cuda10.0.yaml
+++ b/.conda_configs/python3.9_cuda10.0.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.9.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 100
-
-CUDA_VERSION:
-  - 10.0

--- a/.conda_configs/python3.9_cuda10.1.yaml
+++ b/.conda_configs/python3.9_cuda10.1.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.9.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 101
-
-CUDA_VERSION:
-  - 10.1

--- a/.conda_configs/python3.9_cuda11.1.yaml
+++ b/.conda_configs/python3.9_cuda11.1.yaml
@@ -2,7 +2,7 @@ python:
   - 3.9.* *_cpython
 
 CUDA_SHORT_VERSION:
-  - 91
+  - 111
 
 CUDA_VERSION:
-  - 9.1
+  - 11.1

--- a/.conda_configs/python3.9_cuda11.2.yaml
+++ b/.conda_configs/python3.9_cuda11.2.yaml
@@ -2,7 +2,7 @@ python:
   - 3.9.* *_cpython
 
 CUDA_SHORT_VERSION:
-  - 80
+  - 112
 
 CUDA_VERSION:
-  - 8.0
+  - 11.2

--- a/.conda_configs/python3.9_cuda9.0.yaml
+++ b/.conda_configs/python3.9_cuda9.0.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.9.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 90
-
-CUDA_VERSION:
-  - 9.0

--- a/.conda_configs/python3.9_cuda9.2.yaml
+++ b/.conda_configs/python3.9_cuda9.2.yaml
@@ -1,8 +1,0 @@
-python:
-  - 3.9.* *_cpython
-
-CUDA_SHORT_VERSION:
-  - 92
-
-CUDA_VERSION:
-  - 9.2

--- a/recipes/openmm/meta.yaml
+++ b/recipes/openmm/meta.yaml
@@ -23,7 +23,7 @@ source:
 extra:
   #upload: betacuda{{ CUDA_SHORT_VERSION }}{{ ",beta" if CUDA_SHORT_VERSION == "92" else ""}}
   #upload: devcuda{{ CUDA_SHORT_VERSION }}{{ ",dev" if CUDA_SHORT_VERSION == "92" else ""}}
-  upload: {{ CUDA_STR[1:] }}{{",main" if CUDA_STR[-3:] == "102" else "" }}
+  upload: {{ CUDA_STR[1:] }}{{",main" if CUDA_STR[-3:] == "112" else "" }}
   force_upload: True
   scheduled: True
 


### PR DESCRIPTION
This PR updates the CUDA versions to match conda-forge (currently 10.2, 11.0, 11.1, 11.2)