### PR TITLE
Fix failing docker builds by addressing glibc issue

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,3 @@
 provider:
+os_version:
+  linux_64: cos7  

--- a/recipes/openmm/meta.yaml
+++ b/recipes/openmm/meta.yaml
@@ -44,6 +44,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - sysroot_linux-64 2.17  # [linux64]    
     - {{ compiler('cxx') }}
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
     - cmake


### PR DESCRIPTION
Attempts to fix https://github.com/openmm/openmm/issues/3530

This may require we update our docker images to CentOS 7